### PR TITLE
Enable border-box for pseudo elements (:before, :after)

### DIFF
--- a/compass/stylesheets/toolkit/_border-box.scss
+++ b/compass/stylesheets/toolkit/_border-box.scss
@@ -5,4 +5,6 @@
 //  From http://paulirish.com/2012/box-sizing-border-box-ftw/
 ////////////////////////
 @import "compass/css3/box-sizing";
-* { @include box-sizing('border-box'); }
+*,
+*:after,
+*:before { @include box-sizing('border-box'); }


### PR DESCRIPTION
the \* selector on it's own won't effect pseudo elements, here is a js fiddle demonstrating it http://jsfiddle.net/grewis/nHaxL/4/
