### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "toolkit",
+  "version": "1.1.1",
+  "main": "compass/stylesheets/_toolkit.scss",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components",
+    "sass",
+    "stylesheets",
+    "config.rb",
+    "index.html"
+  ],
+  "dependencies": {
+    "compass-breakpoint": ">=2.0.2",
+    "sassy-strings": "git://github.com/Snugug/Sassy-Strings.git",
+    "color-schemer": ">=0.2.3"
+  }
+}


### PR DESCRIPTION
Adding a bower.json so people can install Team Sass components with [Bower](http://bower.io).

Let's use the Breakpoint issue for general discussion about the bower.jsons.
https://github.com/Team-Sass/breakpoint/pull/49
