### PR TITLE
Revise bower.json name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "toolkit",
+  "name": "sass-toolkit",
   "version": "1.1.1",
   "main": "compass/stylesheets/_toolkit.scss",
   "ignore": [


### PR DESCRIPTION
Changes bower registered name to 'sass-toolkit'.
