### PR TITLE
Allow separate support for ie6 and/or ie7 in clearfix mixin

### DIFF
--- a/compass/stylesheets/toolkit/_clearfix.scss
+++ b/compass/stylesheets/toolkit/_clearfix.scss
@@ -70,7 +70,7 @@ $clearfix-extend: false !default;
 $legacy-support-for-mozilla: true !default;
 
 @mixin clearfix($extend: $clearfix-extend) {
-  @if $legacy-support-for-ie6 and $legacy-support-for-ie7 and not $legacy-support-for-mozilla {
+  @if $legacy-support-for-ie6 or $legacy-support-for-ie7 and not $legacy-support-for-mozilla {
     @if $extend {
       @extend %clearfix-micro;
     }
@@ -91,7 +91,7 @@ $legacy-support-for-mozilla: true !default;
       }
     }
   }
-  @else if $legacy-support-for-ie6 and $legacy-support-for-ie7 and $legacy-support-for-mozilla {
+  @else if $legacy-support-for-ie6 or $legacy-support-for-ie7 and $legacy-support-for-mozilla {
     @if $extend {
       @extend %clearfix-legacy;
     }


### PR DESCRIPTION
Right now you need to specify support for IE6 _and_ IE7 if you want to output the legacy or micro clearfix.

So in a context where:

<pre>
$legacy-support-for-ie6: false;
$legacy-support-for-ie7: true;
$legacy-support-for-mozilla: false | true;
</pre>


You always get the modern one.
