### PR TITLE
Fix media queries for Retina

### DIFF
--- a/compass/stylesheets/toolkit/_pe.scss
+++ b/compass/stylesheets/toolkit/_pe.scss
@@ -146,14 +146,14 @@ $replace-text-inline-element: false !default;
   //   like I would like to or you would do by hand. This sucks, but it's the
   //   only way to get it to work for now.
   //////////////////////////////
-  @media (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (-o-max-device-pixel-ratio: 7/5), (max-resolution: 1.4dppx), (max-resolution: 134.4dpi) {
+  @media (max-resolution: 1.4dppx), (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (max-resolution: 134.4dpi) {
     background: {
       image: $sprite-map;
       repeat: no-repeat;
     }
     @include sprite($sprite-map, $sprite);
   }
-  @media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx), (min-resolution: 144dpi) {
+  @media (min-resolution: 1.5dppx), (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background: {
       image: $retina-map;
       repeat: no-repeat;
@@ -206,7 +206,7 @@ $replace-text-inline-element: false !default;
       }
     }
 
-    @media (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (-o-max-device-pixel-ratio: 7/5), (max-resolution: 1.4dppx), (max-resolution: 134.4dpi) {
+    @media (max-resolution: 1.4dppx), (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (max-resolution: 134.4dpi) {
       %#{sprite-map-name($png-path)}-image-map {
         background: {
           image: $png-path;
@@ -214,7 +214,7 @@ $replace-text-inline-element: false !default;
         }
       }
     }
-    @media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx), (min-resolution: 144dpi) {
+    @media (min-resolution: 1.5dppx), (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
       %#{sprite-map-name($png2x-path)}-image-map {
         background: {
           image: $png2x-path;

--- a/compass/stylesheets/toolkit/_pe.scss
+++ b/compass/stylesheets/toolkit/_pe.scss
@@ -146,14 +146,14 @@ $replace-text-inline-element: false !default;
   //   like I would like to or you would do by hand. This sucks, but it's the
   //   only way to get it to work for now.
   //////////////////////////////
-  @media (max-resolution: 1.4dppx), (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (max-resolution: 134.4dpi) {
+  @media (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (-o-max-device-pixel-ratio: 7/5), (max-resolution: 1.4dppx), (max-resolution: 134.4dpi) {
     background: {
       image: $sprite-map;
       repeat: no-repeat;
     }
     @include sprite($sprite-map, $sprite);
   }
-  @media (min-resolution: 1.5dppx), (-webkit-max-device-pixel-ratio: 1.5), (max--moz-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
+  @media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx), (min-resolution: 144dpi) {
     background: {
       image: $retina-map;
       repeat: no-repeat;
@@ -206,7 +206,7 @@ $replace-text-inline-element: false !default;
       }
     }
 
-    @media (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (-o-max-device-pixel-ratio: 7/5), (min-resolution: 1.4dppx), (min-resolution: 134.4dpi) {
+    @media (-webkit-max-device-pixel-ratio: 1.4), (max--moz-device-pixel-ratio: 1.4), (-o-max-device-pixel-ratio: 7/5), (max-resolution: 1.4dppx), (max-resolution: 134.4dpi) {
       %#{sprite-map-name($png-path)}-image-map {
         background: {
           image: $png-path;
@@ -214,7 +214,7 @@ $replace-text-inline-element: false !default;
         }
       }
     }
-    @media (-webkit-max-device-pixel-ratio: 1.5), (max--moz-device-pixel-ratio: 1.5), (-o-max-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx), (min-resolution: 144dpi) {
+    @media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx), (min-resolution: 144dpi) {
       %#{sprite-map-name($png2x-path)}-image-map {
         background: {
           image: $png2x-path;


### PR DESCRIPTION
Retina queries aren't working as expected.
- The media query for non-retina displays should use the max-resolution, instead of min-resolution;
- The media query for Retina diplays should use the min value on the prefixed device-pixel-ratio.

Also, i added the Opera prefix on both queries.
