### PR TITLE
Use default sprite map dimensions and positioning for retina background

### DIFF
--- a/compass/stylesheets/toolkit/_pe.scss
+++ b/compass/stylesheets/toolkit/_pe.scss
@@ -159,9 +159,12 @@ $replace-text-inline-element: false !default;
       repeat: no-repeat;
     }
     @if $with-dimensions {
-      background-size: image-width($sprite-file) image-height($sprite-file);
+      background-size: image-width(sprite-path($sprite-map)) image-height(sprite-path($sprite-map));
+      @include sprite($sprite-map, $sprite);
     }
-    @include sprite($retina-map, $sprite);
+    @else {
+      @include sprite($retina-map, $sprite);
+    }
   }
 
     //////////////////////////////


### PR DESCRIPTION
The current retina background mixin uses the sprite file dimensions to set the background size for the sprite map. This doesn't work properly when using multiple sprites.

This pull request sets the retina background size and positioning, using the properties from the default sprite map, when $with-dimensions is true.
