### PR TITLE
Introduced shortcut clearfix mixins, so that clearfixing from media queries becomes possible without using the inconvenient main mixin

### DIFF
--- a/compass/stylesheets/toolkit/_clearfix.scss
+++ b/compass/stylesheets/toolkit/_clearfix.scss
@@ -74,8 +74,12 @@ $toolkit-clearfix: true;
 //
 // From http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php
 //////////////////////////////
-%clearfix-legacy {
+@mixin clearfix-legacy {
   @include clearfix(false, 'legacy');
+}
+
+%clearfix-legacy {
+  @include clearfix-legacy;
 }
 
 //////////////////////////////
@@ -84,8 +88,12 @@ $toolkit-clearfix: true;
 // For when you need old IE support, but not concerned with old Firefox
 // From http://nicolasgallagher.com/better-float-containment-in-ie/
 //////////////////////////////
-%clearfix-micro {
+@mixin clearfix-micro {
   @include clearfix(false, 'micro');
+}
+
+%clearfix-micro {
+  @include clearfix-micro;
 }
 
 //////////////////////////////
@@ -95,6 +103,10 @@ $toolkit-clearfix: true;
 //
 // From http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php
 //////////////////////////////
-%clearfix {
+@mixin clearfix-modern {
   @include clearfix(false, 'modern');
+}
+
+%clearfix, %clearfix-modern {
+  @include clearfix-modern;
 }


### PR DESCRIPTION
Sometimes it's necessary to apply clearfixes from inside media queries. But currently Toolkit offers handy clearfix shortcuts only in a form of extendables, and SASS does not allow extending from media queries.

Using the main mixin is kinda burdensome due to the fact that a never used argument goes first and you have to either provide the first argument (`@include clearfix(false, 'micro');`) or provide the name for the second argument (`@include clearfix($direct: 'micro');`).

So i added a shorthand mixin for every clearfix flavor. Now it's possible to do simply `@include clearfix-micro;` without any arguments and even parentheses.

It gets even better in SASS syntax:

``` sass
.region
  @extend %clearfix-micro

.block
  @media (min-width: 400px)
    +clearfix-micro
```

PS I think that SASS should allow extending from media queries by simply declaring extendable classes inside CSS media queries. I don't see why that's impossible. Are you with me?
