### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-toolkit",
-  "version": "1.1.1",
+  "version": ">=1.1.1",
   "main": "compass/stylesheets/_toolkit.scss",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
prevent bower sass-toolkit#\*          mismatch Version declared in the json (1.1.1) is different than the resolved one (1.3.8)
