### PR TITLE
Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ A mixin for applying a core set of styling for icon fonts, based on styling form
 
 ### Content Fade In
 
-One of the big challenges of working with webfonts is the Flash of Unstyled Text. It happens when webfonts get applied after content is already rendered on the page, usually causing a jarring jump when they are. To help combat this, Google and Typekit teamed up to create [WebFont Loader](https://developers.google.com/fonts/docs/webfont_loader), a JavaScript library to add Font Events that you can hook in to using CSS and JavaScript to know whether your webfonts are loading, have successfully loaded, or have failed to load. As [Typekit](http://help.typekit.com/customer/portal/articles/6852) suggests, these can be utilized to more effectively take control over your staying and prevent FOUT. The `content-fade-in` mixin will set your content to a 0 opacity (allowing the page to paint correctly even while it's not visible) and when a loading class has been removed, will fade your content in to an opacity of 1. Y
+One of the big challenges of working with webfonts is the Flash of Unstyled Text. It happens when webfonts get applied after content is already rendered on the page, usually causing a jarring jump when they are. To help combat this, Google and Typekit teamed up to create [WebFont Loader](https://developers.google.com/fonts/docs/webfont_loader), a JavaScript library to add Font Events that you can hook in to using CSS and JavaScript to know whether your webfonts are loading, have successfully loaded, or have failed to load. As [Typekit](http://help.typekit.com/customer/portal/articles/6852) suggests, these can be utilized to more effectively take control over your staying and prevent FOUT. The `content-fade-in` mixin will set your content to a 0 opacity (allowing the page to paint correctly even while it's not visible) and when a loading class has been removed, will fade your content in to an opacity of 1.
 
 #### @include content-fade-in([$duration, $loading, $extend])
 
@@ -267,7 +267,7 @@ img, video {
 
 ## Nested Context
 
-Sometimes we may be inside of an element but need somthing the width of its parent.
+Sometimes we may be inside of an element but need something the width of its parent.
 
 ![Basic nested context](http://img.pgdn.us/nested-context.png)
 


### PR DESCRIPTION
There was an extra 'Y' at the end of a paragraph, and 'something' was misspelled.
