### PR TITLE
Bump to Sass 3.4 and Compass 1.0 (gemspec + Gemfile), updated tests control output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source 'https://rubygems.org'
 
 gem 'sass',               "~>3.3"
-gem 'compass',            "~> 1.0.0.alpha.18"
+gem 'compass',            "~> 1.0"
 
 group :test do
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # Pull gems from RubyGems
 source 'https://rubygems.org'
 
-gem 'sass',               "~>3.3.0"
+gem 'sass',               "~>3.3"
 gem 'compass',            "~> 1.0.0.alpha.18"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,26 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    chunky_png (1.3.0)
+    chunky_png (1.3.1)
     colorize (0.6.0)
-    compass (1.0.0.alpha.19)
+    compass (1.0.1)
       chunky_png (~> 1.2)
-      compass-core (~> 1.0.0.alpha.19)
-      compass-import-once (~> 1.0.3)
-      json
-      listen (~> 1.1.0)
-      sass (>= 3.3.0, < 3.5)
-    compass-core (1.0.0.alpha.19)
+      compass-core (~> 1.0.1)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.1)
       multi_json (~> 1.0)
       sass (>= 3.3.0, < 3.5)
-    compass-import-once (1.0.3)
+    compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     diffy (3.0.2)
     ffi (1.9.3)
-    json (1.8.1)
-    listen (1.1.6)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-      rb-kqueue (>= 0.2)
-    multi_json (1.9.0)
+    multi_json (1.10.1)
     rake (10.1.1)
     rb-fsevent (0.9.4)
-    rb-inotify (0.9.3)
-      ffi (>= 0.5.0)
-    rb-kqueue (0.2.2)
+    rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     sass (3.4.0)
 
@@ -36,7 +29,7 @@ PLATFORMS
 
 DEPENDENCIES
   colorize (~> 0.6.0)
-  compass (~> 1.0.0.alpha.18)
+  compass (~> 1.0)
   diffy (~> 3.0.1)
   rake
   sass (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       ffi (>= 0.5.0)
     rb-kqueue (0.2.2)
       ffi (>= 0.5.0)
-    sass (3.3.3)
+    sass (3.4.0)
 
 PLATFORMS
   ruby
@@ -39,4 +39,4 @@ DEPENDENCIES
   compass (~> 1.0.0.alpha.18)
   diffy (~> 3.0.1)
   rake
-  sass (~> 3.3.0)
+  sass (~> 3.3)

--- a/tests/controls/02-colors.css
+++ b/tests/controls/02-colors.css
@@ -2,20 +2,20 @@
   * Colors Tints and Shades
 **/
 .color--tint {
-  _setting--tint-color: white;
+  _setting--tint-color: #fff;
   _test: "tint(#b4d455, 25%)";
   _result: #c6de7f;
   /* Set New Tint Color */
-  _setting--tint-color: #eeeeee;
+  _setting--tint-color: #eee;
   _test: "tint(#b4d455, 25%)";
   _result: #c2da7b;
 }
 .color--shade {
-  _setting--shade-color: black;
+  _setting--shade-color: #000;
   _test: "shade(#b4d455, 25%)";
   _result: #879f3f;
   /* Set New Shade Color */
-  _setting--shade-color: #111111;
+  _setting--shade-color: #111;
   _test: "shade(#b4d455, 25%)";
   _result: #8ba344;
 }
@@ -51,12 +51,12 @@
   _result: red #d80026 #cc0033 #bf003f #b2004c;
 }
 .color--tint-stack {
-  _setting--tint-color: #eeeeee;
+  _setting--tint-color: #eee;
   _test: "tint-stack(red, 15%, 20%, 25%, 30%)";
   _result: red #fc2323 #fb2f2f #fa3b3b #f94747;
 }
 .color--tint-stack {
-  _setting--shade-color: #111111;
+  _setting--shade-color: #111;
   _test: "shade-stack(red, 15%, 20%, 25%, 30%)";
   _result: red #db0202 #cf0303 #c30404 #b70505;
 }

--- a/tests/controls/12-triangle.css
+++ b/tests/controls/12-triangle.css
@@ -2,7 +2,7 @@
   * Triangle
 **/
 .triangle--default {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -11,11 +11,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-bottom-color: black;
+  border-bottom-color: #000;
   border-width: 0 0.5em 1em 0.5em;
 }
 .triangle--color {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -28,7 +28,7 @@
   border-width: 0 0.5em 1em 0.5em;
 }
 .triangle--height {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -37,11 +37,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-bottom-color: black;
+  border-bottom-color: #000;
   border-width: 0 0.5em 20px 0.5em;
 }
 .triangle--width {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -50,11 +50,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-bottom-color: black;
+  border-bottom-color: #000;
   border-width: 0 0.75rem 1em 0.75rem;
 }
 .triangle--angle-number {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -63,11 +63,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-left-color: black;
+  border-left-color: #000;
   border-width: 0.30556em 0 0.69444em 1em;
 }
 .triangle--angle-top {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -76,11 +76,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-bottom-color: black;
+  border-bottom-color: #000;
   border-width: 0 0.5em 1em 0.5em;
 }
 .triangle--angle-top-right {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -89,11 +89,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-right-color: black;
+  border-right-color: #000;
   border-width: 0em 1em 1em 0;
 }
 .triangle--angle-right {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -102,11 +102,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-left-color: black;
+  border-left-color: #000;
   border-width: 0.5em 0 0.5em 1em;
 }
 .triangle--angle-bottom-right {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -115,11 +115,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-bottom-color: black;
+  border-bottom-color: #000;
   border-width: 0 0em 1em 1em;
 }
 .triangle--angle-bottom {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -128,11 +128,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-top-color: black;
+  border-top-color: #000;
   border-width: 1em 0.5em 0 0.5em;
 }
 .triangle--angle-bottom-left {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -141,11 +141,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-left-color: black;
+  border-left-color: #000;
   border-width: 1em 0 0em 1em;
 }
 .triangle--angle-left {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -154,11 +154,11 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-right-color: black;
+  border-right-color: #000;
   border-width: 0.5em 1em 0.5em 0;
 }
 .triangle--angle-top-left {
-  _setting-triangle-color: black;
+  _setting-triangle-color: #000;
   _setting-triangle-height: 1em;
   _setting-triangle-width: 1em;
   _setting-triangle-angle: 0;
@@ -167,6 +167,6 @@
   width: 0;
   height: 0;
   border: 0 solid transparent;
-  border-top-color: black;
+  border-top-color: #000;
   border-width: 1em 1em 0 0em;
 }

--- a/tests/controls/15-underline.css
+++ b/tests/controls/15-underline.css
@@ -2,96 +2,96 @@
   * Underline
 **/
 .underline-default {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline";
   text-decoration: none;
   background-repeat: repeat-x;
-  background-image: linear-gradient(to top, white 75%, #0000ee 75%);
+  background-image: linear-gradient(to top, #fff 75%, #00e 75%);
   background-size: 0.125em 0.1875em;
   background-position: 0 1.125em;
-  text-shadow: 0.0625em 0.0625em 0 white, -0.0625em 0 0 white;
+  text-shadow: 0.0625em 0.0625em 0 #fff, -0.0625em 0 0 #fff;
 }
 .underline-background {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline($background: #f00)";
   text-decoration: none;
   background-repeat: repeat-x;
-  background-image: linear-gradient(to top, red 75%, #0000ee 75%);
+  background-image: linear-gradient(to top, #f00 75%, #00e 75%);
   background-size: 0.125em 0.1875em;
   background-position: 0 1.125em;
-  text-shadow: 0.0625em 0.0625em 0 red, -0.0625em 0 0 red;
+  text-shadow: 0.0625em 0.0625em 0 #f00, -0.0625em 0 0 #f00;
 }
 .underline-color {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline($color: #f00)";
   text-decoration: none;
   background-repeat: repeat-x;
-  background-image: linear-gradient(to top, white 75%, red 75%);
+  background-image: linear-gradient(to top, #fff 75%, #f00 75%);
   background-size: 0.125em 0.1875em;
   background-position: 0 1.125em;
-  text-shadow: 0.0625em 0.0625em 0 white, -0.0625em 0 0 white;
+  text-shadow: 0.0625em 0.0625em 0 #fff, -0.0625em 0 0 #fff;
 }
 .underline-clear-descenders {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline($clear-descenders: false)";
   text-decoration: none;
   background-repeat: repeat-x;
-  background-image: linear-gradient(to top, white 75%, #0000ee 75%);
+  background-image: linear-gradient(to top, #fff 75%, #00e 75%);
   background-size: 0.125em 0.1875em;
   background-position: 0 1.125em;
 }
 .underline-distance {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline($distance: 2)";
   text-decoration: none;
   background-repeat: repeat-x;
-  background-image: linear-gradient(to top, white 75%, #0000ee 75%);
+  background-image: linear-gradient(to top, #fff 75%, #00e 75%);
   background-size: 0.125em 0.1875em;
   background-position: 0 2.125em;
-  text-shadow: 0.0625em 0.0625em 0 white, -0.0625em 0 0 white;
+  text-shadow: 0.0625em 0.0625em 0 #fff, -0.0625em 0 0 #fff;
 }
 .underline-width {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline($width: 1)";
   text-decoration: none;
   background-repeat: repeat-x;
-  background-image: linear-gradient(to top, white 75%, #0000ee 75%);
+  background-image: linear-gradient(to top, #fff 75%, #00e 75%);
   background-size: 0.125em 0.125em;
   background-position: 0 1.0625em;
-  text-shadow: 0.0625em 0.0625em 0 white, -0.0625em 0 0 white;
+  text-shadow: 0.0625em 0.0625em 0 #fff, -0.0625em 0 0 #fff;
 }
 .underline-first-extend {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline($background: green, $extend: true)";
-  background-image: linear-gradient(to top, green 75%, #0000ee 75%);
+  background-image: linear-gradient(to top, green 75%, #00e 75%);
   background-size: 0.125em 0.1875em;
   background-position: 0 1.125em;
   text-shadow: 0.0625em 0.0625em 0 green, -0.0625em 0 0 green;
@@ -101,14 +101,14 @@
   background-repeat: repeat-x;
 }
 .underline-second-extend {
-  _setting-underline-background: white;
-  _setting-underline-color: #0000ee;
+  _setting-underline-background: #fff;
+  _setting-underline-color: #00e;
   _setting-underline-clear-descenders: true;
   _setting-underline-distance: 1;
   _setting-underline-width: 2;
   _test: "@include underline($color: green, $extend: true)";
-  background-image: linear-gradient(to top, white 75%, green 75%);
+  background-image: linear-gradient(to top, #fff 75%, green 75%);
   background-size: 0.125em 0.1875em;
   background-position: 0 1.125em;
-  text-shadow: 0.0625em 0.0625em 0 white, -0.0625em 0 0 white;
+  text-shadow: 0.0625em 0.0625em 0 #fff, -0.0625em 0 0 #fff;
 }

--- a/toolkit.gemspec
+++ b/toolkit.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
 
 
   # Dependent Gems
-  s.add_dependency("sass",      ["~>3.3.0"])
+  s.add_dependency("sass",      ["~>3.3"])
 end


### PR DESCRIPTION
This is a swifter duplicate of #72.

Test output:

```
$ bundle list | grep 'sass\|compass'
  * compass (1.0.1)
  * compass-core (1.0.1)
  * compass-import-once (1.0.5)
  * sass (3.4.0)


$ bundle exec ruby .unit_tests.rb
...
14 tests, 14 assertions, 0 failures, 0 errors, 0 skips
ruby -v: ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-linux]
```
