### PR TITLE
avoiding duplicate code produced by _placeholders

### DIFF
--- a/stylesheets/toolkit/_placeholders.scss
+++ b/stylesheets/toolkit/_placeholders.scss
@@ -1,5 +1,5 @@
 $Private-Toolkit-Placeholders: (
-);
+)!default;
 
 //////////////////////////////
 // Placeholder Get/Set


### PR DESCRIPTION
I added the `!default` flag to the initial definition of `$Private-Toolkit-Placeholders`

This avoids the duplication of code in cases where the toolkit is imported by multiple subfiles. This way every module file can declare its own dependencies.
# Example

An `app.scss` file imports multiple indipendently developed modules using the toolkit:
### Folder structure:
- app.scss
  - modules/_moduleA.scss
  - modules/_moduleB.scss
#### source app.scss

``` scss
@import "_modules/_moduleA.scss";
@import "_modules/_moduleB.scss";
```
#### source _moduleA.scss

``` scss
@import "sass-toolkit/stylesheets/toolkit";

.moduleA{
    @include clearfix(true);
}
```
#### source _moduleB.scss

``` scss
@import "sass-toolkit/stylesheets/toolkit";

.moduleA{
    @include clearfix(true);
}
```
#### output without !default

Since both module files import the toolkit. The first line of `_placeholders.scss` causes the resets the map`$Private-Toolkit-Placeholders` at each import-point. This results in a duplicate output of clearfix even though the `[$extend]` has been set to `true`. 

``` css
.moduleA:after {
  content: "";
  display: table;
  clear: both;
}

.moduleB:after {
  content: "";
  display: table;
  clear: both;
}
```
#### Output width !default

Adding the `!default` flag to the end of `$Private-Toolkit-Placeholders` fixes this problem. If `$Private-Toolkit-Placeholders` has already been assigned to, it won’t be re-assigned. 

``` css
.moduleA:after, .moduleB:after {
  content: "";
  display: table;
  clear: both;
}
```

Signed-off-by: Michael Gehrmann michael.gehrmann@gmail.com
