### PR TITLE
Fix syntax issue with LibSass

### DIFF
--- a/stylesheets/toolkit/_colors.scss
+++ b/stylesheets/toolkit/_colors.scss
@@ -173,3 +173,4 @@
 
   @return $list;
 }
+

--- a/stylesheets/toolkit/_colors.scss
+++ b/stylesheets/toolkit/_colors.scss
@@ -110,7 +110,7 @@
 // Color Scales
 //////////////////////////////
 @function color-scale($main, $secondary, $steps: null) {
-  $steps: if($steps != null, $steps, toolkit-get('color scale steps'));;
+  $steps: if($steps != null, $steps, toolkit-get('color scale steps'));
 
   $list: $main;
 


### PR DESCRIPTION
I was getting this error when processing with LibSass 3.0.2:

```
lib/sass_modules/vendor/sass-toolkit/stylesheets/toolkit/colors:113: only variable declarations and control directives are allowed inside functions
```

Resolves #85 
